### PR TITLE
Allow to load in json context so that references can be loaded in

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -43,6 +43,14 @@ var globalSetup = function(opts) {
   return _frisbyGlobalSetup;
 };
 
+var _schemaValidator = new JSONSchemaValidator()
+
+// Load schemas globally
+var loadJSONSchema = function(obj) {
+  for (var prop in obj) {
+    _schemaValidator.addSchema(obj[prop], prop)
+  }
+}
 
 var _toType = function(obj) {
   return ({}).toString.call(obj).match(/\s([a-z|A-Z]+)/)[1].toLowerCase();
@@ -351,7 +359,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
       outgoing = {
         json: params.json || (_frisbyGlobalSetup && _frisbyGlobalSetup.request && _frisbyGlobalSetup.request.json || false),
         uri: null,
-        body: params.body || undefined,
+        body: params.body || null,
         method: 'GET',
         headers: {}
       };
@@ -423,7 +431,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
   // Add the topic for the specified request to the context of the current
   // batch used by this suite.
   //
-  this.current.it = function (cb) {
+  this.current.it = function () {
     self.currentRequestFinished = false;
     var start = (new Date).getTime();
     var runCallback = function(err, res, body) {
@@ -450,11 +458,6 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
         body: body,
         time: diff
       };
-
-      // call caller's callback
-      if (cb && typeof cb === "function") {
-        cb(self.current.response);
-      }
     };
 
     outgoing['timeout'] = self._timeout;
@@ -727,17 +730,13 @@ Frisby.prototype.expectJSON = function(jsonTest) {
 
 
 // Helper to validate JSON response against provided JSONSchema structure or document
-Frisby.prototype.expectJSONSchema = function(path, jsonSchema) {
+Frisby.prototype.expectJSONSchema = function(jsonSchema, context) {
   var self       = this,
       args       = Array.prototype.slice.call(arguments),
-      path       = typeof args[0] === 'string' && args.shift(),
       jsonSchema = (typeof args[0] === 'object' || typeof args[0] === 'string') && args.shift();
+      context = (typeof args[0] === 'object') && args.shift();
 
-  // If called with only a single argument, ensure path is null
-  if(_.isUndefined(jsonSchema) || !jsonSchema) {
-    jsonSchema = path;
-    path = false;
-  }
+  var jsVal = _schemaValidator || new JSONSchemaValidator();
 
   // String = file path
   if(typeof jsonSchema === 'string') {
@@ -751,13 +750,32 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema) {
     }
     var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
     jsonSchema      = JSON.parse(data);
+    jsVal.addSchema(jsonSchemaFile, jsonSchema)
+  }
+
+  if(context) {
+    for (var jsonSchemaSet in context) {
+      var jsonSchemaFile = jsonSchemaSet;
+      // Allows relative file paths from Frisby specs
+      if(!fs.existsSync(context[jsonSchemaSet])) {
+        var trace       = stackTrace.parse(new Error());
+        var callingFile = trace[1].getFileName();
+        var callingDir  = fspath.dirname(callingFile)
+        jsonSchemaFile = fspath.join(callingDir, context[jsonSchemaSet]);
+      }
+      var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
+      jsonSchema      = JSON.parse(data);
+      // Remove required as jsonschema is not able to handle external requires...
+      delete jsonSchema.required
+      jsVal.addSchema(jsonSchemaFile, jsonSchema)
+    }
   }
 
   this.current.expects.push(function() {
     var jsonBody = _jsonParse(self.current.response.body);
     // With path syntax
-    _withPath.call(self, path, jsonBody, function(jsonChunk) {
-      var jsVal = new JSONSchemaValidator();
+    _withPath.call(self, null, jsonBody, function(jsonChunk) {
+
       var res = jsVal.validate(jsonChunk, jsonSchema);
       if(res.valid === true) {
         // Use assertion to keep assertion count accurate
@@ -768,7 +786,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema) {
       } else {
         // JSONSchema failures - show each one to user
         throw new Error("JSONSchema validation failed with the following errors: \n\t> " +
-          res.errors.map(function(err, field) { return err.stack.replace('instance', path); }).join("\n\t> ")
+          res.errors.map(function(err, field) { return err.stack; }).join("\n\t> ")
         );
       }
     });
@@ -877,67 +895,49 @@ Frisby.prototype.expectJSONLength = function(expectedLength) {
 
 
 // Debugging helper to inspect HTTP request sent by Frisby
-Frisby.prototype.inspectRequest = function(message) {
+Frisby.prototype.inspectRequest = function() {
   var self = this;
   this.after(function(err, res, body) {
-    if (message) {
-        console.log(message)
-    }
     console.log(self.currentRequestFinished.req);
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response received from server
-Frisby.prototype.inspectResponse = function(message) {
+Frisby.prototype.inspectResponse = function() {
   this.after(function(err, res, body) {
-    if (message) {
-        console.log(message)
-    }
     console.log(res);
   });
   return this;
 };
 
 // Debugging helper to inspect the HTTP headers that are returned from the server
-Frisby.prototype.inspectHeaders = function(message){
+Frisby.prototype.inspectHeaders = function(){
   this.after(function(err, res, body) {
-    if (message) {
-        console.log(message)
-    }
     console.log(res.headers);
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response body content received from server
-Frisby.prototype.inspectBody = function(message) {
+Frisby.prototype.inspectBody = function() {
   this.after(function(err, res, body) {
-    if (message) {
-        console.log(message)
-    }
     console.log(body);
   });
   return this;
 };
 
 // Debugging helper to inspect JSON response body content received from server
-Frisby.prototype.inspectJSON = function(message) {
+Frisby.prototype.inspectJSON = function() {
   this.after(function(err, res, body) {
-    if (message) {
-        console.log(message);
-    }
     console.log(util.inspect(_jsonParse(body), false, 10, true));
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response code received from server
-Frisby.prototype.inspectStatus = function(message) {
+Frisby.prototype.inspectStatus = function() {
   this.after(function(err, res, body) {
-    if (message) {
-        console.log(message)
-    }
     console.log(res.statusCode);
   });
   return this;
@@ -960,7 +960,7 @@ Frisby.prototype.waits = function(millis) {
 Frisby.prototype.after = function(cb) {
   var self = this;
   this.current.after.push(function() {
-    cb.call(this, self.current.response.error, self.currentRequestFinished.res, self.current.response.body, self.current.response.headers);
+    cb.call(this, self.current.response.error, self.currentRequestFinished.res, self.current.response.body);
   });
   return this;
 };
@@ -970,9 +970,8 @@ Frisby.prototype.after = function(cb) {
 Frisby.prototype.afterJSON = function(cb) {
   var self = this;
   this.current.after.push(function() {
-    var responseHeaders = _jsonParse(self.current.response.headers);
     var bodyJSON = _jsonParse(self.current.response.body);
-    cb.call(this, bodyJSON, responseHeaders);
+    cb.call(this, bodyJSON);
   });
   return this;
 };
@@ -1016,119 +1015,104 @@ Frisby.prototype.setResponseHeader = function(key, value) {
   return this.current.response.headers[key.toLowerCase()];
 };
 
-Frisby.prototype.ttoss = function(retry){
-  return this.toss(retry, true);
-};
 
 //
 // Toss (Run the current Frisby test)
 //
-Frisby.prototype.toss = function(retry, only) {
+Frisby.prototype.toss = function(retry) {
   var self = this;
   if (typeof retry === "undefined") {
     retry = self.current.retry;
   }
 
-  var describeFunc = function() {
+  // Assemble all Jasmine tests and RUN them!
+  describe('Frisby Test: ' + self.current.describe, function() {
 
-    // Add custom matchers to spec
-    beforeEach(function(){
-      jasmine.addMatchers(exports.matchers);
-    });
-
-    // Spec test (async: beware of jasmine's default 5sec timeout for async spec's)
-    it("\n\t[ " + self.current.itInfo + " ]", function(done) {
+    // Spec test
+    it("\n\t[ " + self.current.itInfo + " ]", function() {
       // Ensure "it" scope is accessible to tests
       var it = this;
 
-      // results_ seems to no long exsist on jasmine2.0, mock it
-      it.results_ = {
-        failedCount: 0
-      };
-
-      // launch request
-      // repeat request for self.current.retry times if request does not respond with self._timeout ms (except for POST requests)
-      var tries = 0;
-      var retries = (self.current.outgoing.method.toUpperCase() == "POST") ? 0 : self.current.retry;
-
-      // wait optinally, launch request
       if (self.current.waits > 0) {
-        setTimeout(makeRequest, self.current.waits);
-      } else {
-        makeRequest();
+        waits(self.current.waits);
       }
 
+      // Don't retry POST
+      var retries = (self.current.outgoing.method.toUpperCase() == "POST") ? 0 : self.current.retry;
 
-      function makeRequest(){
-        var requestFinished = false;
-        var timeoutFinished = false;
-        tries++;
+      // we need to loop for the first run + how many times we want to retry
+      // they will abort if the test succeeds
+      for (var x = 0; x < retries + 1; x++) {
+        runs(function() {
+          if (typeof this.n === "undefined") {
+            this.n = 0;
+          }
+          else {
+            this.n += 1;
+          }
+          if (this.abort) {
+            return;
+          }
 
-        var timeoutId = setTimeout(function maxWait(){
-          timeoutFinished = true;
-          if (tries < retries+1){
-
+          if (this.n > 0) {
             it.results_.totalCount = it.results_.passedCount = it.results_.failedCount = 0;
             it.results_.skipped = false;
             it.results_.items_ = [];
 
-            process.stdout.write('R')
-            makeRequest();
-          } else {
-            // should abort instead (it.spec.fail ?)
-            it.results_.failedCount = 1;
-            after();
-            // assert();
-          }
-        }, self._timeout);
+            process.stdout.write('R');
 
-        self.current.it(function(data) {
-          if (!timeoutFinished) {
-            clearTimeout(timeoutId);
-            assert();
+            waits(self.current.retry_backoff);
           }
+
+          // Run "it" spec
+          self.current.it();
+
+          waitsFor(function(){
+            return self.currentRequestFinished;
+          }, "HTTP Request timed out before completing", self._timeout);
+
+          // Run Asserts
+          runs(function() {
+            if (self.currentRequestFinished) {
+              var i;
+              self.current.expectsFailed = true;
+
+              // if you have no expects, they can't fail
+              if (self.current.expects.length == 0) {
+                retry = -1;
+                this.abort = true;
+                self.current.expectsFailed = false;
+              }
+
+              // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
+              // Some 'expects' helpers add more tests when executed (recursive 'expectJSON' and 'expectJSONTypes', with nested JSON syntax etc.)
+              for(i=0; i < self.current.expects.length; i++) {
+                if(false !== self._exceptionHandler) {
+                  try {
+                    self.current.expects[i].call(it);
+                  } catch(e) {
+                    self._exceptionHandler.call(self, e);
+                  }
+                } else {
+                  self.current.expects[i].call(it);
+                }
+              }
+
+              if (it.results_.failedCount == 0) {
+                retry = -1;
+                this.abort = true;
+                self.current.expectsFailed = false;
+              }
+            }
+            else {
+              it.results_.failedCount = 1;
+            }
+          });
         });
       }
 
-
-      // Assert callback
-      // called from makeRequest if request has finished successfully
-      function assert() {
-        var i;
-        self.current.expectsFailed = true;
-
-        // if you have no expects, they can't fail
-        if (self.current.expects.length == 0) {
-          retry = -1;
-          self.current.expectsFailed = false;
-        }
-
-        // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
-        // Some 'expects' helpers add more tests when executed (recursive 'expectJSON' and 'expectJSONTypes', with nested JSON syntax etc.)
-        for(i=0; i < self.current.expects.length; i++) {
-          if(false !== self._exceptionHandler) {
-            try {
-              self.current.expects[i].call(it);
-            } catch(e) {
-              self._exceptionHandler.call(self, e);
-            }
-          } else {
-            self.current.expects[i].call(it);
-          }
-        }
-
-        if (it.results_.failedCount == 0) {
-          retry = -1;
-          self.current.expectsFailed = false;
-        }
-
-        // call after()
-        after();
-      }
-
-      // AFTER callback (execute further expects for the current spec)
-      // called from assert()
-      function after() {
+      runs(function() {
+        // AFTER callback
         if(self.current.after) {
 
           if (self.current.expectsFailed && self.current.outgoing.inspectOnFailure) {
@@ -1152,19 +1136,97 @@ Frisby.prototype.toss = function(retry, only) {
             }
           }
         }
-
-        // finally call done to finish spec
-        done();
-      }
-
+      })
     });
-  };
+  });
+};
 
-  // Assemble all Jasmine tests and RUN them!
-  if (only) {
-    ddescribe('Frisby Test: ' + self.current.describe, describeFunc);
-  } else {
-    describe('Frisby Test: ' + self.current.describe, describeFunc);
+
+//
+// Add custom Frisby matchers to Jasmine (globally)
+//
+jasmine.Matchers.prototype.toMatchOrBeNull = function(expected) {
+  this.message = function() {
+    return "Expected '" + this.actual + "' to match '" + expected + "' or be null";
+  }
+  return (new RegExp(expected).test(this.actual)) || (this.actual === null);
+};
+jasmine.Matchers.prototype.toMatchOrBeEmpty = function(expected) {
+  this.message = function() {
+    return "Expected '" + this.actual + "' to match '" + expected + "' or be empty";
+  }
+  return (new RegExp(expected).test(this.actual)) || (this.actual === null) || (this.actual === "");
+};
+jasmine.Matchers.prototype.toBeType = function(expected) {
+  var aType = _toType(this.actual);
+  var eType = _toType(expected);
+  // Function is not a valid JSON type
+  if("function" === eType) {
+    eType = _toType(expected.prototype);
+  }
+  // Custom failure message
+  this.message = function() {
+    return "Expected '" + aType + "' to be type '" + eType + "'";
+  }
+  // Test
+  return aType === eType;
+};
+jasmine.Matchers.prototype.toBeTypeOrNull = function(expected) {
+  var aType = _toType(this.actual);
+  var eType = _toType(expected);
+  // Function is not a valid JSON type
+  if("function" === eType) {
+    eType = _toType(expected.prototype);
+  }
+  // Custom failure message
+  this.message = function() {
+    return "Expected '" + aType + "' to be type '" + eType + "' or null";
+  }
+  // Test
+  return (this.actual === null) || (_toType(this.actual) === eType);
+};
+jasmine.Matchers.prototype.toBeTypeOrUndefined = function(expected) {
+  var aType = _toType(this.actual);
+  var eType = _toType(expected);
+  // Function is not a valid JSON type
+  if("function" === eType) {
+    eType = _toType(expected.prototype);
+  }
+  // Custom failure message
+  this.message = function() {
+    return "Expected '" + aType + "' to be type '" + eType + "' or null";
+  }
+  // Test
+  return (this.actual === undefined) || (_toType(this.actual) === eType);
+};
+jasmine.Matchers.prototype.toContainJson = function(expected, isNot) {
+  this.message = function() {
+    return "Actual JSON did not match expected";
+  }
+
+  // Way of allowing custom failure message - by throwing exceptions in utility function
+  try {
+    return _jsonContains(this.actual, expected);
+  } catch(e) {
+    // Fail test if there is a match failure and it is not an inverse test (for non-match)
+    if(!this.isNot && !isNot) {
+      this.spec.fail(e);
+    }
+  }
+};
+jasmine.Matchers.prototype.toContainJsonTypes = function(expected, isNot) {
+  this.message = function() {
+    return "Actual JSON types did not match expected";
+  }
+
+  // Way of allowing custom failure message - by throwing exceptions in utility function
+  try {
+    return _jsonContainsTypes(this.actual, expected);
+  } catch(e) {
+    // Fail test if there is a match failure and it is not an inverse test (for non-match)
+    if(!this.isNot && !isNot) {
+      this.spec.fail(e);
+    }
   }
 };
 
@@ -1173,7 +1235,7 @@ Frisby.prototype.toss = function(retry, only) {
 // Parse body as JSON, ensuring not to re-parse when body is already an object (thanks @dcaylor)
 //
 function _jsonParse(body) {
-  var json = "";
+  json = "";
   try {
     json = (typeof body === "object") ? body : JSON.parse(body);
   } catch(e) {
@@ -1300,114 +1362,6 @@ function _jsonContainsTypes(jsonBody, jsonTest) {
 }
 
 
-////////////////////
-// Module Exports //
-////////////////////
-
-
-//
-// Export Frisby Matchers (to be used in unit tests; to be applied in toss()'s beforeEach')
-//
-exports.matchers = {
-  toMatchOrBeNull: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        return {
-          pass: (new RegExp(expected).test(actual)) || (actual === null)
-        }
-      }
-    }
-  },
-  toMatchOrBeEmpty: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        return {
-          pass: (new RegExp(expected).test(actual)) || (actual === null) || (actual === "")
-        }
-      }
-    }
-  },
-  toBeType: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        var aType = _toType(actual);
-        var eType = _toType(expected);
-        // Function is not a valid JSON type
-        if("function" === eType) {
-          eType = _toType(expected.prototype);
-        }
-        return {
-          pass: aType === eType
-        }
-      }
-    }
-  },
-  toBeTypeOrNull: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        var aType = _toType(actual);
-        var eType = _toType(expected);
-        // Function is not a valid JSON type
-        if("function" === eType) {
-          eType = _toType(expected.prototype);
-        }
-        return {
-          pass: (actual === null) || (_toType(actual) === eType)
-        }
-      }
-    }
-  },
-  toBeTypeOrUndefined: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        var aType = _toType(actual);
-        var eType = _toType(expected);
-        // Function is not a valid JSON type
-        if("function" === eType) {
-          eType = _toType(expected.prototype);
-        }
-        return {
-          pass: (actual === undefined) || (_toType(actual) === eType)
-        }
-      }
-    }
-  },
-  toContainJson: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        // Way of allowing custom failure message - by throwing exceptions in utility function
-        try {
-          return {
-            pass: _jsonContains(actual, expected)
-          };
-        } catch(e) {
-          return {
-            pass: false
-          };
-        }
-      }
-    }
-  },
-  toContainJsonTypes: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        // Way of allowing custom failure message - by throwing exceptions in utility function
-        try {
-          return {
-            pass: _jsonContainsTypes(actual, expected)
-          };
-        } catch(e) {
-          // Fail test if there is a match failure and it is not an inverse test (for non-match)
-          return {
-            pass: false
-          };
-        }
-      }
-    }
-  }
-}
-
-
 //
 // Main Frisby method used to start new spec tests
 //
@@ -1419,4 +1373,4 @@ exports.withPath = _withPath;
 
 // Public methods and properties
 exports.globalSetup = globalSetup;
-exports.version = '0.8.4';
+exports.version = '0.8.5';


### PR DESCRIPTION
This follows the best practice on how the jsonschema expects additional schemas to be loaded. One bug I did find is that the required argument is not fully supported for additional required json schemas. I'm trying to replicate this and create a bug report for the jsonschema module but to that time being, this fixes it for me.
